### PR TITLE
Atualizar Pessoa Fisica - Controllers

### DIFF
--- a/src/server/controllers/clients/pessoaFisica/UpdateById.ts
+++ b/src/server/controllers/clients/pessoaFisica/UpdateById.ts
@@ -1,0 +1,62 @@
+import { validation } from '../../../shared/middlewares/validation';
+import * as yup from 'yup';
+import { IUpdatePessoaFisica } from '../../../database/models/Clients/Cliente';
+import { cpf } from 'cpf-cnpj-validator';
+import { Request, Response } from 'express';
+import { StatusCodes } from 'http-status-codes';
+
+interface IParamsProps {
+  id: number
+}
+
+const enderecoSchema = yup.object().shape({
+  rua: yup.string().optional(),
+  numero: yup.number().optional(),
+  bairro: yup.string().optional(),
+  cidade: yup.string().optional(),
+});
+
+const bodySchema = yup.object().shape({
+  nome: yup.string().optional().min(3),
+  endereco: enderecoSchema.optional(),
+  cpf: yup.string().optional().test('cpf', 'Cpf inválido', value => !value || cpf.isValid(value)),
+  telefone: yup.string().optional().matches(/^\d{10,11}$/, 'Telefone inválido'),
+}).noUnknown();
+
+export const updateByIdValidation = validation((getSchema) => ({
+  params: getSchema<IParamsProps>(yup.object().shape({
+    id: yup.number().integer().required().moreThan(0)
+  })),
+  body: getSchema<IUpdatePessoaFisica>(bodySchema)
+}));
+
+export const updateById = async (req: Request, res: Response) => {
+
+  const dataString = JSON.stringify(req.body);
+  const dataParse: IUpdatePessoaFisica = JSON.parse(dataString);
+
+  const allowedKeys = ['nome', 'endereco', 'cpf', 'telefone', 'email'];
+  const receivedKeys = Object.keys(dataParse);
+  const hasRequiredProperty = allowedKeys.some(key => key in dataParse);
+
+  if (!hasRequiredProperty) {
+    return res.status(StatusCodes.BAD_REQUEST).json({
+      errors: {
+        default: 'Para atualização de pessoa fisica deve pelo menos ter um dos seguintes cadastros [nome, endereco, cpf, telefone, tipo]'
+      }
+    });
+  }
+
+  const hasInvalidProperty = receivedKeys.some(key => !allowedKeys.includes(key));
+
+  if (hasInvalidProperty) {
+    return res.status(StatusCodes.BAD_REQUEST).json({
+      errors: {
+        default: 'O corpo da requisição contém propriedades não permitidas.'
+      }
+    });
+  }
+
+  return res.status(StatusCodes.ACCEPTED).json(dataParse);
+
+};

--- a/src/server/controllers/clients/pessoaFisica/index.ts
+++ b/src/server/controllers/clients/pessoaFisica/index.ts
@@ -1,5 +1,7 @@
 import * as create from './Create';
+import * as UpdateById from './UpdateById';
 
 export const pessoaFisicaControllers = {
   ...create,
+  ...UpdateById
 };

--- a/src/server/database/models/Clients/Cliente.ts
+++ b/src/server/database/models/Clients/Cliente.ts
@@ -11,3 +11,17 @@ export interface IPessoaFisica{
   cpf: string,
   tipo: 'fisico'
 }
+
+export interface IEnderecoUpdate {
+  rua?: string,
+  numero?: number,
+  bairro?: string,
+  cidade?: string,
+}
+
+export interface IUpdatePessoaFisica {
+  cpf?: string;
+  nome?: string;
+  endereco?: IEnderecoUpdate;
+  telefone?: string
+}

--- a/src/server/routes/clients/pessoaFisicaRoute.ts
+++ b/src/server/routes/clients/pessoaFisicaRoute.ts
@@ -3,7 +3,8 @@ import { pessoaFisicaControllers } from '../../controllers/clients/pessoaFisica'
 
 export const pessoaFisicaRouters = (router: Router) => {
   const routers = [
-    router.post('/clientes/pessoaFisica', pessoaFisicaControllers.createValidation, pessoaFisicaControllers.create)
+    router.post('/clientes/pessoaFisica', pessoaFisicaControllers.createValidation, pessoaFisicaControllers.create),
+    router.put('/clientes/pessoaFisica/:id', pessoaFisicaControllers.updateByIdValidation, pessoaFisicaControllers.updateById)
   ];
 
   return {...routers};


### PR DESCRIPTION
criado a controller para atualziar o cliente e as models de cliente Update e endereço Update para que não seja obrigatório a enviar todos os campos do cliente.
implementado condições de validações do corpo, caso seja enviado algum parâmetro além do esperado no corpo, passa na validação antes de fazer a requisição no banco de dados